### PR TITLE
fix typo in var name USE_LEDS_KEYPAD (it should be USE_KEYPAD_LEDS) f…

### DIFF
--- a/config/a4-2wires/Configuration.h
+++ b/config/a4-2wires/Configuration.h
@@ -82,7 +82,7 @@ See LICENSE.txt for details
 #define SIMPLE_LED_PIN 13
 
 // keypad leds
-#define USE_LEDS_KEYPAD false
+#define USE_KEYPAD_LEDS false
 #define KEYPAD_LED_PIN_UP A0
 #define KEYPAD_LED_PIN_RIGHT A3
 #define KEYPAD_LED_PIN_DOWN A2

--- a/config/a4-3wires/Configuration.h
+++ b/config/a4-3wires/Configuration.h
@@ -82,7 +82,7 @@ See LICENSE.txt for details
 #define SIMPLE_LED_PIN 13
 
 // keypad leds
-#define USE_LEDS_KEYPAD false
+#define USE_KEYPAD_LEDS false
 #define KEYPAD_LED_PIN_UP A0
 #define KEYPAD_LED_PIN_RIGHT A3
 #define KEYPAD_LED_PIN_DOWN A2

--- a/config/latest/Configuration.h
+++ b/config/latest/Configuration.h
@@ -82,7 +82,7 @@ See LICENSE.txt for details
 #define SIMPLE_LED_PIN 13
 
 // keypad leds
-#define USE_LEDS_KEYPAD true
+#define USE_KEYPAD_LEDS true
 #define KEYPAD_LED_PIN_UP A0
 #define KEYPAD_LED_PIN_RIGHT A3
 #define KEYPAD_LED_PIN_DOWN A2

--- a/config/micro/Configuration.h
+++ b/config/micro/Configuration.h
@@ -82,7 +82,7 @@ See LICENSE.txt for details
 #define SIMPLE_LED_PIN 13
 
 // keypad leds
-#define USE_LEDS_KEYPAD true
+#define USE_KEYPAD_LEDS true
 #define KEYPAD_LED_PIN_UP A2
 #define KEYPAD_LED_PIN_RIGHT A3
 #define KEYPAD_LED_PIN_DOWN A0


### PR DESCRIPTION
…or Configuraton.h files in config directory in version 1.6.0