### PR TITLE
Configuration for reverse turning steppers

### DIFF
--- a/Escornabot/Configuration.h
+++ b/Escornabot/Configuration.h
@@ -96,7 +96,12 @@ See LICENSE.txt for details
 
 #ifdef ENGINE_TYPE_STEPPERS
 
-// stepper pin setup (digital outputs)
+// define stepper sequence depending of the stepper turn direction
+//      0 => Steppers turns forward       other => Steppers turns reverse
+#define STEPPERS_ROTATION 0
+
+#if  STEPPERS_ROTATION == 0
+// stepper pin setup (digital outputs) forward
 #define STEPPERS_MOTOR_RIGHT_IN1 5
 #define STEPPERS_MOTOR_RIGHT_IN2 4
 #define STEPPERS_MOTOR_RIGHT_IN3 3
@@ -105,6 +110,19 @@ See LICENSE.txt for details
 #define STEPPERS_MOTOR_LEFT_IN2 8
 #define STEPPERS_MOTOR_LEFT_IN3 7
 #define STEPPERS_MOTOR_LEFT_IN4 6
+
+#else
+// stepper pin setup (digital outputs) reverse
+#define STEPPERS_MOTOR_RIGHT_IN1 2
+#define STEPPERS_MOTOR_RIGHT_IN2 3
+#define STEPPERS_MOTOR_RIGHT_IN3 4
+#define STEPPERS_MOTOR_RIGHT_IN4 5
+#define STEPPERS_MOTOR_LEFT_IN1 6
+#define STEPPERS_MOTOR_LEFT_IN2 7
+#define STEPPERS_MOTOR_LEFT_IN3 8
+#define STEPPERS_MOTOR_LEFT_IN4 9
+#endif
+
 
 // step calibration
 #define STEPPERS_STEPS_PER_SECOND 1000


### PR DESCRIPTION
This new configuration parameter (circa 100) let you solve easily the situation when the two steppers rotate in the wrong way. It will not work if only one of then is rotating in the wrong way.